### PR TITLE
fix: fix pagination crash when no reviews, center pagination inside grids

### DIFF
--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
@@ -183,7 +183,12 @@ const BeerPage = async ({ params, searchParams }: BeerPageProps) => {
           <BeerReviewCard key={review.id} review={review} />
         ))}
 
-        <Pagination current={reviews.page.current} total={reviews.page.total} />
+        <div className="col-span-2">
+          <Pagination
+            current={reviews.page.current}
+            total={reviews.page.total}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
@@ -183,12 +183,11 @@ const BeerPage = async ({ params, searchParams }: BeerPageProps) => {
           <BeerReviewCard key={review.id} review={review} />
         ))}
 
-        <div className="col-span-2">
-          <Pagination
-            current={reviews.page.current}
-            total={reviews.page.total}
-          />
-        </div>
+        <Pagination
+          current={reviews.page.current}
+          total={reviews.page.total}
+          className="col-span-2"
+        />
       </div>
     </div>
   );

--- a/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
@@ -80,7 +80,12 @@ const ProfilePage = async ({ params, searchParams }: ProfilePageProps) => {
           <UserReviewCard key={review.id} review={review} />
         ))}
 
-        <Pagination current={reviews.page.current} total={reviews.page.total} />
+        <div className="col-span-2">
+          <Pagination
+            current={reviews.page.current}
+            total={reviews.page.total}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
@@ -80,12 +80,11 @@ const ProfilePage = async ({ params, searchParams }: ProfilePageProps) => {
           <UserReviewCard key={review.id} review={review} />
         ))}
 
-        <div className="col-span-2">
-          <Pagination
-            current={reviews.page.current}
-            total={reviews.page.total}
-          />
-        </div>
+        <Pagination
+          current={reviews.page.current}
+          total={reviews.page.total}
+          className="col-span-2"
+        />
       </div>
     </div>
   );

--- a/src/app/_components/ui/pagination/index.tsx
+++ b/src/app/_components/ui/pagination/index.tsx
@@ -6,13 +6,15 @@ import { useTranslations } from "next-intl";
 import { useCallback } from "react";
 
 import { Link, usePathname } from "@/lib/i18n";
+import { cn } from "@/lib/tailwind";
 
 interface PaginationProps {
   current: number;
   total: number;
+  className?: string;
 }
 
-const Pagination = ({ current, total }: PaginationProps) => {
+const Pagination = ({ current, total, className }: PaginationProps) => {
   const t = useTranslations();
 
   const pathname = usePathname();
@@ -44,7 +46,7 @@ const Pagination = ({ current, total }: PaginationProps) => {
       role="navigation"
       aria-label="pagination"
       data-slot="pagination"
-      className="mx-auto flex w-full justify-center"
+      className={cn("mx-auto flex w-full justify-center", className)}
     >
       <ul className="flex flex-row items-center gap-x-3">
         <li>

--- a/src/lib/pagination/index.ts
+++ b/src/lib/pagination/index.ts
@@ -9,7 +9,7 @@ export const getPaginatedResults = <T>(
     count,
     page: {
       current: page,
-      total: Math.ceil(count / limit),
+      total: Math.max(Math.ceil(count / limit), 1),
     },
   };
 };

--- a/src/lib/pagination/index.ts
+++ b/src/lib/pagination/index.ts
@@ -9,7 +9,7 @@ export const getPaginatedResults = <T>(
     count,
     page: {
       current: page,
-      total: Math.max(Math.ceil(count / limit), 1),
+      total: count === 0 ? 1 : Math.ceil(count / limit),
     },
   };
 };


### PR DESCRIPTION
⚠️ could not test locally the fixes because of missing env variables + no easy way to replicate database 

i found two issues while testing the app tonight: 
- the pagination component was not centered when placed inside a grid. 
- the pagination was displayed even when a user had no reviews, causing a crash when interacted with.