### PR TITLE
Chore: upgrade page props type safety

### DIFF
--- a/src/app/[locale]/(auth)/password-forgotten/page.tsx
+++ b/src/app/[locale]/(auth)/password-forgotten/page.tsx
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import PasswordForgottenForm from "@/app/[locale]/(auth)/password-forgotten/_components/form";
+import { passwordForgottenSearchParamsSchema } from "@/app/[locale]/(auth)/password-forgotten/schemas";
 import { auth } from "@/lib/auth/server";
 import { redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
@@ -16,15 +17,9 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-interface PasswordForgottenPageProps {
-  searchParams: Promise<{
-    email?: string;
-  }>;
-}
-
 const PasswordForgottenPage = async ({
   searchParams,
-}: PasswordForgottenPageProps) => {
+}: PageProps<"/[locale]/password-forgotten">) => {
   const t = await getTranslations();
 
   const locale = await getLocale();
@@ -37,10 +32,14 @@ const PasswordForgottenPage = async ({
     redirect({ href: Routes.HOME, locale });
   }
 
-  const { email } = await searchParams;
+  const searchParamsResult = passwordForgottenSearchParamsSchema.safeParse(
+    await searchParams,
+  );
+
+  const email = searchParamsResult.success ? searchParamsResult.data.email : "";
 
   return (
-    <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-128">
+    <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-lg">
       <div className="flex w-full flex-col gap-y-4">
         <h1 className="text-[40px] leading-none font-semibold">
           {t("auth.passwordForgotten.title")}
@@ -49,7 +48,7 @@ const PasswordForgottenPage = async ({
         <p>{t("auth.passwordForgotten.description")}</p>
       </div>
 
-      <PasswordForgottenForm email={email ?? ""} />
+      <PasswordForgottenForm email={email} />
     </div>
   );
 };

--- a/src/app/[locale]/(auth)/password-forgotten/schemas.ts
+++ b/src/app/[locale]/(auth)/password-forgotten/schemas.ts
@@ -5,3 +5,7 @@ import { zEmail } from "@/lib/validator";
 export const passwordForgottenSchema = z.object({
   email: zEmail,
 });
+
+export const passwordForgottenSearchParamsSchema = z.object({
+  email: zEmail.optional().default(""),
+});

--- a/src/app/[locale]/(auth)/reset-password/_components/form/index.tsx
+++ b/src/app/[locale]/(auth)/reset-password/_components/form/index.tsx
@@ -73,7 +73,7 @@ const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
                   "flex flex-col rounded-[7px] *:-m-px",
                   "focus-within:outline-3 focus-within:outline-offset-1",
                   "focus-within:outline-primary-700 dark:focus-within:outline-primary-100",
-                  "before:bg-foreground relative before:absolute before:inset-[-1px] before:bottom-[-3px] before:z-[-1] before:rounded",
+                  "before:bg-foreground relative before:absolute before:-inset-px before:bottom-[-3px] before:z-[-1] before:rounded",
                   "**:data-[slot=input-container]:rounded-none **:data-[slot=input-container]:focus-within:z-50!",
                   "**:data-[slot=input-container]:before:bottom-0",
                   "not-focus-within:**:data-[slot=input-container]:last-of-type:before:-bottom-0.5!",

--- a/src/app/[locale]/(auth)/reset-password/page.tsx
+++ b/src/app/[locale]/(auth)/reset-password/page.tsx
@@ -40,6 +40,32 @@ const ResetPasswordPage = async ({
     return redirect({ href: Routes.HOME, locale });
   }
 
+  if (searchParamsResult.data.error) {
+    return (
+      <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-3xl">
+        <div className="flex w-full flex-col gap-y-4">
+          <h1 className="text-[40px] leading-none font-semibold">
+            {t("auth.resetPassword.title")}
+          </h1>
+
+          <p>
+            {t.rich("auth.resetPassword.actions.requestNewToken", {
+              br: () => <br />,
+              link: (chunks) => (
+                <Link
+                  href={Routes.PASSWORD_FORGOTTEN}
+                  className="text-primary-700 underline"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   if (searchParamsResult.data.token) {
     return (
       <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-3xl">
@@ -56,29 +82,9 @@ const ResetPasswordPage = async ({
     );
   }
 
-  return (
-    <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-3xl">
-      <div className="flex w-full flex-col gap-y-4">
-        <h1 className="text-[40px] leading-none font-semibold">
-          {t("auth.resetPassword.title")}
-        </h1>
-
-        <p>
-          {t.rich("auth.resetPassword.actions.requestNewToken", {
-            br: () => <br />,
-            link: (chunks) => (
-              <Link
-                href={Routes.PASSWORD_FORGOTTEN}
-                className="text-primary-700 underline"
-              >
-                {chunks}
-              </Link>
-            ),
-          })}
-        </p>
-      </div>
-    </div>
-  );
+  // This should never happen
+  console.error("No token or error");
+  redirect({ href: Routes.HOME, locale });
 };
 
 export default ResetPasswordPage;

--- a/src/app/[locale]/(auth)/reset-password/page.tsx
+++ b/src/app/[locale]/(auth)/reset-password/page.tsx
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import ResetPasswordForm from "@/app/[locale]/(auth)/reset-password/_components/form";
+import { resetPasswordSearchParamsSchema } from "@/app/[locale]/(auth)/reset-password/schemas";
 import { auth } from "@/lib/auth/server";
 import { Link, redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
@@ -16,14 +17,9 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-interface ResetPasswordPageProps {
-  searchParams: Promise<{
-    token?: string;
-    error?: string;
-  }>;
-}
-
-const ResetPasswordPage = async ({ searchParams }: ResetPasswordPageProps) => {
+const ResetPasswordPage = async ({
+  searchParams,
+}: PageProps<"/[locale]/reset-password">) => {
   const t = await getTranslations();
 
   const locale = await getLocale();
@@ -36,41 +32,17 @@ const ResetPasswordPage = async ({ searchParams }: ResetPasswordPageProps) => {
     redirect({ href: Routes.HOME, locale });
   }
 
-  const { token, error } = await searchParams;
+  const searchParamsResult = resetPasswordSearchParamsSchema.safeParse(
+    await searchParams,
+  );
 
-  if (!token && !error) {
+  if (!searchParamsResult.success) {
     return redirect({ href: Routes.HOME, locale });
   }
 
-  if (error) {
+  if (searchParamsResult.data.token) {
     return (
-      <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-128">
-        <div className="flex w-full flex-col gap-y-4">
-          <h1 className="text-[40px] leading-none font-semibold">
-            {t("auth.resetPassword.title")}
-          </h1>
-
-          <p>
-            {t.rich("auth.resetPassword.actions.requestNewToken", {
-              br: () => <br />,
-              link: (chunks) => (
-                <Link
-                  href={Routes.PASSWORD_FORGOTTEN}
-                  className="text-primary-700 underline"
-                >
-                  {chunks}
-                </Link>
-              ),
-            })}
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  if (token) {
-    return (
-      <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-128">
+      <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-3xl">
         <div className="flex w-full flex-col gap-y-4">
           <h1 className="text-[40px] leading-none font-semibold">
             {t("auth.resetPassword.title")}
@@ -79,14 +51,34 @@ const ResetPasswordPage = async ({ searchParams }: ResetPasswordPageProps) => {
           <p>{t("auth.resetPassword.description")}</p>
         </div>
 
-        <ResetPasswordForm token={token} />
+        <ResetPasswordForm token={searchParamsResult.data.token} />
       </div>
     );
   }
 
-  // This should never happen
-  console.error("No token or error");
-  redirect({ href: Routes.HOME, locale });
+  return (
+    <div className="mx-auto flex h-screen w-full flex-col items-center justify-center gap-y-12 p-12 md:w-3xl">
+      <div className="flex w-full flex-col gap-y-4">
+        <h1 className="text-[40px] leading-none font-semibold">
+          {t("auth.resetPassword.title")}
+        </h1>
+
+        <p>
+          {t.rich("auth.resetPassword.actions.requestNewToken", {
+            br: () => <br />,
+            link: (chunks) => (
+              <Link
+                href={Routes.PASSWORD_FORGOTTEN}
+                className="text-primary-700 underline"
+              >
+                {chunks}
+              </Link>
+            ),
+          })}
+        </p>
+      </div>
+    </div>
+  );
 };
 
 export default ResetPasswordPage;

--- a/src/app/[locale]/(auth)/reset-password/schemas.ts
+++ b/src/app/[locale]/(auth)/reset-password/schemas.ts
@@ -20,3 +20,14 @@ export const resetPasswordSchema = z
     message: "form.errors.PASSWORDS_DO_NOT_MATCH",
     path: ["confirmPassword"],
   });
+
+export const resetPasswordSearchParamsSchema = z.union([
+  z.object({
+    token: z.string(),
+    error: z.string().optional(),
+  }),
+  z.object({
+    token: z.string().optional(),
+    error: z.string(),
+  }),
+]);

--- a/src/app/[locale]/(auth)/sign-in/page.tsx
+++ b/src/app/[locale]/(auth)/sign-in/page.tsx
@@ -55,7 +55,7 @@ const SignInPage = async () => {
       >
         <Wave className="fill-primary absolute top-[calc(-5%+10px)] z-50 h-1/20" />
 
-        <div className="flex w-full flex-col items-end gap-y-2 md:w-128">
+        <div className="flex w-full flex-col items-end gap-y-2 md:w-lg">
           <SignInForm />
         </div>
 

--- a/src/app/[locale]/(auth)/sign-up/email-verification/page.tsx
+++ b/src/app/[locale]/(auth)/sign-up/email-verification/page.tsx
@@ -1,15 +1,12 @@
 import { MailCheckIcon } from "lucide-react";
 import { getLocale, getTranslations } from "next-intl/server";
 
+import { emailVerificationSearchParamsSchema } from "@/app/[locale]/(auth)/sign-up/email-verification/schemas";
 import { isUserVerified } from "@/domain/auth";
 import { Link, redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
 
 import type { Metadata } from "next";
-
-interface SignUpEmailVerificationPageProps {
-  searchParams: Promise<{ email: string }>;
-}
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations();
@@ -21,14 +18,19 @@ export async function generateMetadata(): Promise<Metadata> {
 
 const SignUpEmailVerificationPage = async ({
   searchParams,
-}: SignUpEmailVerificationPageProps) => {
+}: PageProps<"/[locale]/sign-up/email-verification">) => {
   const t = await getTranslations();
   const locale = await getLocale();
 
-  const { email } = await searchParams;
-  if (!email) {
-    redirect({ href: Routes.HOME, locale });
+  const searchParamsResult = emailVerificationSearchParamsSchema.safeParse(
+    await searchParams,
+  );
+
+  if (!searchParamsResult.success) {
+    return redirect({ href: Routes.HOME, locale });
   }
+
+  const { email } = searchParamsResult.data;
 
   const isVerified = await isUserVerified(email);
   if (isVerified === null || isVerified) {

--- a/src/app/[locale]/(auth)/sign-up/email-verification/schemas.ts
+++ b/src/app/[locale]/(auth)/sign-up/email-verification/schemas.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+import { zEmail } from "@/lib/validator";
+
+export const emailVerificationSearchParamsSchema = z.object({
+  email: zEmail,
+});

--- a/src/app/[locale]/(auth)/sign-up/page.tsx
+++ b/src/app/[locale]/(auth)/sign-up/page.tsx
@@ -41,7 +41,7 @@ const SignUpPage = async () => {
       >
         <Wave className="fill-primary absolute top-[calc(-5%+10px)] z-50 h-1/20" />
 
-        <div className="flex w-full flex-col items-end gap-y-2 md:w-128">
+        <div className="flex w-full flex-col items-end gap-y-2 md:w-lg">
           <SignUpForm />
         </div>
 

--- a/src/app/[locale]/(business)/(with-header)/_components/header/index.tsx
+++ b/src/app/[locale]/(business)/(with-header)/_components/header/index.tsx
@@ -25,7 +25,7 @@ const Header = () => {
         <span>Zythogora</span>
       </Link>
 
-      <HeaderSearchBar className="grow md:w-128 md:grow-0" />
+      <HeaderSearchBar className="grow md:w-lg md:grow-0" />
 
       <UserMenu className="md:justify-self-end" />
     </div>

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/opengraph-image.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/opengraph-image.tsx
@@ -9,14 +9,9 @@ import {
 } from "@/app/_components/opengraph-preview/utils";
 import { getBeerBySlug } from "@/domain/beers";
 
-interface Props {
-  params: Promise<{
-    brewerySlug: string;
-    beerSlug: string;
-  }>;
-}
-
-export async function generateImageMetadata({ params }: Props) {
+export async function generateImageMetadata({
+  params,
+}: PageProps<"/[locale]/breweries/[brewerySlug]/beers/[beerSlug]">) {
   const { brewerySlug, beerSlug } = await params;
 
   const beer = await getBeerBySlug(beerSlug, brewerySlug).catch(() => null);
@@ -33,7 +28,9 @@ export async function generateImageMetadata({ params }: Props) {
   ];
 }
 
-export default async function Image({ params }: Props) {
+export default async function Image({
+  params,
+}: PageProps<"/[locale]/breweries/[brewerySlug]/beers/[beerSlug]">) {
   const t = await getTranslations();
   const formatter = await getFormatter();
 

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
@@ -19,18 +19,15 @@ import { exhaustiveCheck } from "@/lib/typescript/utils";
 
 import type { Metadata } from "next";
 
-interface BeerPageProps {
-  params: Promise<{
-    brewerySlug: string;
-    beerSlug: string;
-  }>;
-  searchParams: Promise<{
-    page?: string;
-  }>;
-}
-
 export async function generateStaticParams(): Promise<
-  Awaited<BeerPageProps["params"]>[]
+  Array<
+    Omit<
+      Awaited<
+        PageProps<"/[locale]/breweries/[brewerySlug]/beers/[beerSlug]">["params"]
+      >,
+      "locale"
+    >
+  >
 > {
   if (config.next.staticGeneration === StaticGenerationMode.NONE) {
     // There's a bug in Next.js that crashes dynamic routes when using
@@ -72,7 +69,7 @@ export async function generateStaticParams(): Promise<
 
 export async function generateMetadata({
   params,
-}: BeerPageProps): Promise<Metadata> {
+}: PageProps<"/[locale]/breweries/[brewerySlug]/beers/[beerSlug]">): Promise<Metadata> {
   const t = await getTranslations();
 
   const { brewerySlug, beerSlug } = await params;
@@ -104,7 +101,10 @@ export async function generateMetadata({
   };
 }
 
-const BeerPage = async ({ params, searchParams }: BeerPageProps) => {
+const BeerPage = async ({
+  params,
+  searchParams,
+}: PageProps<"/[locale]/breweries/[brewerySlug]/beers/[beerSlug]">) => {
   const t = await getTranslations();
 
   const locale = await getLocale();

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/opengraph-image.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/opengraph-image.tsx
@@ -9,11 +9,9 @@ import {
 } from "@/app/_components/opengraph-preview/utils";
 import { getBreweryBySlug } from "@/domain/breweries";
 
-interface Props {
-  params: Promise<{ brewerySlug: string }>;
-}
-
-export async function generateImageMetadata({ params }: Props) {
+export async function generateImageMetadata({
+  params,
+}: PageProps<"/[locale]/breweries/[brewerySlug]">) {
   const { brewerySlug } = await params;
 
   const brewery = await getBreweryBySlug(brewerySlug).catch(() => null);
@@ -30,7 +28,9 @@ export async function generateImageMetadata({ params }: Props) {
   ];
 }
 
-export default async function Image({ params }: Props) {
+export default async function Image({
+  params,
+}: PageProps<"/[locale]/breweries/[brewerySlug]">) {
   const t = await getTranslations();
 
   const { brewerySlug } = await params;

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/page.tsx
@@ -20,17 +20,13 @@ import { exhaustiveCheck } from "@/lib/typescript/utils";
 
 import type { Metadata } from "next";
 
-interface BreweryPageProps {
-  params: Promise<{
-    brewerySlug: string;
-  }>;
-  searchParams: Promise<{
-    page?: string;
-  }>;
-}
-
 export async function generateStaticParams(): Promise<
-  Awaited<BreweryPageProps["params"]>[]
+  Array<
+    Omit<
+      Awaited<PageProps<"/[locale]/breweries/[brewerySlug]">["params"]>,
+      "locale"
+    >
+  >
 > {
   if (config.next.staticGeneration === StaticGenerationMode.NONE) {
     // There's a bug in Next.js that crashes dynamic routes when using
@@ -61,7 +57,7 @@ export async function generateStaticParams(): Promise<
 
 export async function generateMetadata({
   params,
-}: BreweryPageProps): Promise<Metadata> {
+}: PageProps<"/[locale]/breweries/[brewerySlug]">): Promise<Metadata> {
   const t = await getTranslations();
 
   const { brewerySlug } = await params;
@@ -92,7 +88,10 @@ export async function generateMetadata({
   };
 }
 
-const BreweryPage = async ({ params, searchParams }: BreweryPageProps) => {
+const BreweryPage = async ({
+  params,
+  searchParams,
+}: PageProps<"/[locale]/breweries/[brewerySlug]">) => {
   const locale = await getLocale();
 
   const { brewerySlug } = await params;

--- a/src/app/[locale]/(business)/(with-header)/friend-requests/accept/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/friend-requests/accept/page.tsx
@@ -13,15 +13,9 @@ import { Link, redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
 import { generatePath } from "@/lib/routes/utils";
 
-interface AcceptFriendRequestPageProps {
-  searchParams: Promise<{
-    id: string;
-  }>;
-}
-
 const AcceptFriendRequestPage = async ({
   searchParams,
-}: AcceptFriendRequestPageProps) => {
+}: PageProps<"/[locale]/friend-requests/accept">) => {
   const t = await getTranslations();
 
   const locale = await getLocale();

--- a/src/app/[locale]/(business)/(with-header)/friend-requests/deny/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/friend-requests/deny/page.tsx
@@ -13,15 +13,9 @@ import { redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
 import { generatePath } from "@/lib/routes/utils";
 
-interface RejectFriendRequestPageProps {
-  searchParams: Promise<{
-    id: string;
-  }>;
-}
-
 const RejectFriendRequestPage = async ({
   searchParams,
-}: RejectFriendRequestPageProps) => {
+}: PageProps<"/[locale]/friend-requests/deny">) => {
   const t = await getTranslations();
 
   const locale = await getLocale();

--- a/src/app/[locale]/(business)/(with-header)/users/[username]/opengraph-image.tsx
+++ b/src/app/[locale]/(business)/(with-header)/users/[username]/opengraph-image.tsx
@@ -13,11 +13,9 @@ import {
 } from "@/app/_components/opengraph-preview/utils";
 import { getUserByUsername } from "@/domain/users";
 
-interface Props {
-  params: Promise<{ username: string }>;
-}
-
-export async function generateImageMetadata({ params }: Props) {
+export async function generateImageMetadata({
+  params,
+}: PageProps<"/[locale]/users/[username]">) {
   const { username } = await params;
 
   const user = await getUserByUsername(username).catch(() => null);
@@ -34,7 +32,9 @@ export async function generateImageMetadata({ params }: Props) {
   ];
 }
 
-export default async function Image({ params }: Props) {
+export default async function Image({
+  params,
+}: PageProps<"/[locale]/users/[username]">) {
   const t = await getTranslations();
 
   const { username } = await params;

--- a/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
@@ -22,18 +22,9 @@ import { cn } from "@/lib/tailwind";
 
 import type { Metadata } from "next";
 
-interface ProfilePageProps {
-  params: Promise<{
-    username: string;
-  }>;
-  searchParams: Promise<{
-    page?: string;
-  }>;
-}
-
 export async function generateMetadata({
   params,
-}: ProfilePageProps): Promise<Metadata> {
+}: PageProps<"/[locale]/users/[username]">): Promise<Metadata> {
   const { username } = await params;
 
   const user = await getUserByUsername(username).catch(() => notFound());
@@ -43,7 +34,10 @@ export async function generateMetadata({
   };
 }
 
-const ProfilePage = async ({ params, searchParams }: ProfilePageProps) => {
+const ProfilePage = async ({
+  params,
+  searchParams,
+}: PageProps<"/[locale]/users/[username]">) => {
   const locale = await getLocale();
 
   const { username } = await params;

--- a/src/app/[locale]/(business)/(without-header)/breweries/[brewerySlug]/beers/[beerSlug]/review/page.tsx
+++ b/src/app/[locale]/(business)/(without-header)/breweries/[brewerySlug]/beers/[beerSlug]/review/page.tsx
@@ -10,14 +10,9 @@ import { Routes } from "@/lib/routes";
 import { generatePath } from "@/lib/routes/utils";
 import { cn } from "@/lib/tailwind";
 
-interface ReviewPageProps {
-  params: Promise<{
-    brewerySlug: string;
-    beerSlug: string;
-  }>;
-}
-
-const ReviewPage = async ({ params }: ReviewPageProps) => {
+const ReviewPage = async ({
+  params,
+}: PageProps<"/[locale]/breweries/[brewerySlug]/beers/[beerSlug]/review">) => {
   const locale = await getLocale();
 
   const { brewerySlug, beerSlug } = await params;
@@ -57,7 +52,7 @@ const ReviewPage = async ({ params }: ReviewPageProps) => {
       <div
         className={cn(
           "flex w-fit flex-col gap-y-8",
-          "w-full @3xl:w-192 @3xl:pt-8",
+          "w-full @3xl:w-3xl @3xl:pt-8",
         )}
       >
         <ReviewFormHeader beer={beer} />

--- a/src/app/[locale]/(business)/(without-header)/search/layout.tsx
+++ b/src/app/[locale]/(business)/(without-header)/search/layout.tsx
@@ -28,19 +28,19 @@ const SearchLayout = ({ children }: PropsWithChildren) => {
           <span>Zythogora</span>
         </Link>
 
-        <SearchBar className="w-224 max-w-full" />
+        <SearchBar className="w-4xl max-w-full" />
 
         <UserMenu className="lg:justify-self-end" />
 
         <SearchTabs
           defaultTab="beer"
-          className="w-224 max-w-full lg:col-start-2"
+          className="w-4xl max-w-full lg:col-start-2"
         />
       </div>
 
       <div
         className={cn(
-          "flex w-224 max-w-full flex-col gap-y-4 p-8",
+          "flex w-4xl max-w-full flex-col gap-y-4 p-8",
           "**:[&_a]:focus-within:outline-primary **:[&_a]:rounded-xs **:[&_a]:focus-within:outline-3 **:[&_a]:focus-within:outline-offset-4",
         )}
       >

--- a/src/app/[locale]/(business)/(without-header)/search/page.tsx
+++ b/src/app/[locale]/(business)/(without-header)/search/page.tsx
@@ -12,17 +12,9 @@ import { Routes } from "@/lib/routes";
 
 import type { Metadata } from "next";
 
-interface SearchPageProps {
-  searchParams: Promise<{
-    kind?: string;
-    search?: string;
-    page?: string;
-  }>;
-}
-
 export async function generateMetadata({
   searchParams,
-}: SearchPageProps): Promise<Metadata> {
+}: PageProps<"/[locale]/search">): Promise<Metadata> {
   const t = await getTranslations();
 
   const locale = await getLocale();
@@ -45,7 +37,7 @@ export async function generateMetadata({
   };
 }
 
-const SearchPage = async ({ searchParams }: SearchPageProps) => {
+const SearchPage = async ({ searchParams }: PageProps<"/[locale]/search">) => {
   const t = await getTranslations();
 
   const locale = await getLocale();

--- a/src/app/[locale]/(business)/(without-header)/users/[username]/reviews/[reviewSlug]/page.tsx
+++ b/src/app/[locale]/(business)/(without-header)/users/[username]/reviews/[reviewSlug]/page.tsx
@@ -29,16 +29,9 @@ import { cn } from "@/lib/tailwind";
 
 import type { Metadata } from "next";
 
-interface UserReviewPageProps {
-  params: Promise<{
-    username: string;
-    reviewSlug: string;
-  }>;
-}
-
 export async function generateMetadata({
   params,
-}: UserReviewPageProps): Promise<Metadata> {
+}: PageProps<"/[locale]/users/[username]/reviews/[reviewSlug]">): Promise<Metadata> {
   const t = await getTranslations();
 
   const { username, reviewSlug } = await params;
@@ -82,7 +75,9 @@ export async function generateMetadata({
   };
 }
 
-const UserReviewPage = async ({ params }: UserReviewPageProps) => {
+const UserReviewPage = async ({
+  params,
+}: PageProps<"/[locale]/users/[username]/reviews/[reviewSlug]">) => {
   const t = await getTranslations();
   const formatter = await getFormatter();
 
@@ -108,7 +103,7 @@ const UserReviewPage = async ({ params }: UserReviewPageProps) => {
         <div
           className={cn(
             "mx-auto flex flex-col px-8 py-12",
-            "w-full gap-y-6 md:w-192 md:gap-y-8",
+            "w-full gap-y-6 md:w-3xl md:gap-y-8",
           )}
         >
           <div
@@ -164,7 +159,7 @@ const UserReviewPage = async ({ params }: UserReviewPageProps) => {
             </div>
           </div>
 
-          <div className="grid grid-cols-[repeat(4,minmax(0,1fr))] gap-x-2">
+          <div className="grid grid-cols-4 gap-x-2">
             <DescriptionList
               label={t("common.beer.style")}
               value={review.beer.style}
@@ -194,7 +189,7 @@ const UserReviewPage = async ({ params }: UserReviewPageProps) => {
       <div
         className={cn(
           "mx-auto flex flex-col gap-y-12 px-8 py-12",
-          "w-full md:w-192",
+          "w-full md:w-3xl",
         )}
       >
         <div

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -65,7 +65,7 @@ const HomePage = () => {
       <Bubbles className="z-10" />
 
       <div className="flex h-screen w-full flex-col-reverse">
-        <div className="bg-primary h-[calc(50vh-theme(spacing.6))]" />
+        <div className="bg-primary h-[calc(50vh-(--spacing(6)))]" />
 
         <Wave className="fill-primary h-12" />
       </div>
@@ -78,11 +78,11 @@ const HomePage = () => {
 
         <div
           className={cn(
-            "absolute top-[calc(50vh-theme(spacing.8))] left-[calc(50vw-theme(spacing.8))]",
+            "absolute top-[calc(50vh-(--spacing(8)))] left-[calc(50vw-(--spacing(8)))]",
             "transition-all duration-500",
             "-rotate-5 xl:-rotate-10",
-            "-translate-x-1/2 xl:-translate-x-[calc(theme(spacing.64)+100%-5ch)]",
-            "-translate-y-[calc(100%+theme(spacing.20))] xl:-translate-y-[calc(theme(lineHeight.9)+theme(spacing.2)+theme(spacing.24))]",
+            "-translate-x-1/2 xl:-translate-x-[calc((--spacing(64))+100%-5ch)]",
+            "-translate-y-[calc(100%+(--spacing(20)))] xl:-translate-y-[calc(theme(lineHeight.9)+(--spacing(2))+(--spacing(24)))]",
             "group-data-[open=true]:translate-y-0",
             "group-data-[open=true]:rotate-5 xl:group-data-[open=true]:rotate-10",
             "group-data-[open=true]:top-56 xl:group-data-[open=true]:top-32",
@@ -108,9 +108,9 @@ const HomePage = () => {
             className={cn(
               "stroke-primary absolute top-0 left-0 size-20 origin-top-left overflow-visible fill-none",
               "transition-all duration-500",
-              "translate-x-[5ch] translate-y-[calc(theme(lineHeight.9)+theme(spacing.2))]",
-              "rotate-40 xl:rotate-[20deg]",
-              "group-data-[open=true]:translate-x-[theme(spacing.8)]",
+              "translate-x-[5ch] translate-y-[calc(theme(lineHeight.9)+(--spacing(2)))]",
+              "rotate-40 xl:rotate-20",
+              "group-data-[open=true]:translate-x-8",
               "group-data-[open=true]:left-1/2 xl:group-data-[open=true]:left-full",
               "group-data-[open=true]:-translate-y-2 xl:group-data-[open=true]:translate-y-1/2",
               "group-data-[open=true]:rotate-[-130deg] xl:group-data-[open=true]:rotate-[-110deg]",
@@ -128,7 +128,7 @@ const HomePage = () => {
             className={cn(
               "font-paragraph z-50 text-base font-normal",
               "absolute left-[50vw] -translate-x-1/2",
-              "w-[calc(100%-theme(spacing.16))] md:w-128",
+              "w-[calc(100%-(--spacing(16)))] md:w-lg",
               "transition-all duration-500",
               "top-[50vh] group-data-[open=true]:top-6",
               "-translate-y-1/2 group-data-[open=true]:translate-y-0",
@@ -140,7 +140,7 @@ const HomePage = () => {
 
         <div
           className={cn(
-            "absolute top-[50vh] left-[calc(50vw+theme(spacing.64))]",
+            "absolute top-[50vh] left-[calc(50vw+(--spacing(64)))]",
             "-translate-x-64 translate-y-8 rotate-25 xl:translate-x-0 xl:translate-y-0 xl:rotate-0",
             "transition-all duration-500",
             "group-data-[open=true]:opacity-0",
@@ -169,8 +169,8 @@ const HomePage = () => {
             <p
               className={cn(
                 "absolute origin-top -translate-x-1/2 text-center text-nowrap text-stone-50",
-                "top-[calc(theme(spacing.36)+theme(spacing.2))] left-[calc(theme(spacing.36)+theme(spacing.4))] -rotate-72 text-2xl",
-                "xl:top-[calc(theme(spacing.48)+theme(spacing.1))] xl:left-[calc(theme(spacing.48)+theme(spacing.2))] xl:-rotate-70 xl:text-3xl",
+                "top-[calc((--spacing(36))+(--spacing(2)))] left-[calc((--spacing(36))+(--spacing(4)))] -rotate-72 text-2xl",
+                "xl:top-[calc((--spacing(48))+(--spacing(1)))] xl:left-[calc((--spacing(48))+(--spacing(2)))] xl:-rotate-70 xl:text-3xl",
               )}
             >
               {t.rich("home.callouts.createCollections", {
@@ -202,8 +202,8 @@ const HomePage = () => {
             <p
               className={cn(
                 "absolute origin-top -translate-x-1/2 text-center text-nowrap text-stone-50",
-                "top-[calc(theme(spacing.1)*15+theme(spacing.3))] left-[calc(theme(spacing.1)*27+theme(spacing.1))] -rotate-25 text-2xl",
-                "xl:top-[calc(theme(spacing.20)+theme(spacing.4))] xl:left-36 xl:-rotate-26 xl:text-3xl",
+                "top-[calc(--spacing(1)*15+(--spacing(3)))] left-[calc(--spacing(1)*27+(--spacing(1)))] -rotate-25 text-2xl",
+                "xl:top-[calc(--spacing(20)+(--spacing(4)))] xl:left-36 xl:-rotate-26 xl:text-3xl",
               )}
             >
               {t.rich("home.callouts.writeReviews", {
@@ -235,8 +235,8 @@ const HomePage = () => {
             <p
               className={cn(
                 "absolute origin-top -translate-x-1/2 text-center text-nowrap text-stone-50",
-                "top-[calc(56*theme(spacing.1)+theme(spacing.4))] left-[calc(80*theme(spacing.1)-theme(spacing.3))] -rotate-10 text-2xl",
-                "xl:top-[calc(theme(spacing.56)+theme(spacing.12))] xl:left-[calc(84*theme(spacing.1)+theme(spacing.1))] xl:-rotate-9 xl:text-3xl",
+                "top-[calc(56*(--spacing(1))+(--spacing(4)))] left-[calc(80*(--spacing(1))-(--spacing(3)))] -rotate-10 text-2xl",
+                "xl:top-[calc(--spacing(56)+(--spacing(12)))] xl:left-[calc(84*(--spacing(1))+(--spacing(1)))] xl:-rotate-9 xl:text-3xl",
               )}
             >
               {t.rich("home.callouts.shareThem", {
@@ -265,7 +265,7 @@ const HomePage = () => {
         <div
           className={cn(
             "z-20 grid gap-x-16",
-            "w-[calc(100%-theme(spacing.16))] grid-cols-none grid-rows-[auto_minmax(0,1fr)] gap-y-8",
+            "w-[calc(100%-(--spacing(16)))] grid-cols-none grid-rows-[auto_minmax(0,1fr)] gap-y-8",
             "xl:w-3/5 xl:grid-cols-3 xl:grid-rows-none xl:gap-y-16",
           )}
         >
@@ -293,8 +293,8 @@ const HomePage = () => {
         <div className="z-20 flex w-full flex-col items-center justify-center gap-y-16">
           <div
             className={cn(
-              "grid grid-rows-[calc(theme(spacing.16)+theme(spacing.32))_auto_minmax(0,1fr)] justify-items-center gap-8",
-              "w-[calc(100%-theme(spacing.16))] xl:w-4/5",
+              "grid grid-rows-[calc(--spacing(16)+(--spacing(32)))_auto_minmax(0,1fr)] justify-items-center gap-8",
+              "w-[calc(100%-(--spacing(16)))] xl:w-4/5",
               "grid-cols-1 md:grid-cols-[auto_minmax(0,1fr)] lg:grid-cols-3",
             )}
           >
@@ -348,7 +348,7 @@ const HomePage = () => {
           <div
             className={cn(
               "flex flex-col items-center justify-center gap-y-4",
-              "w-full px-4 sm:w-144",
+              "w-full px-4 sm:w-xl",
             )}
           >
             <p className="text-center">{t("home.donate.description")}</p>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes routing props and hardens query handling across auth, profile, brewery, beer, search, and OG-image pages.
> 
> - Replace custom prop interfaces with `PageProps<...>` across pages and OpenGraph image generators; update `generateStaticParams` return types accordingly
> - Add and use zod schemas for `searchParams` (`passwordForgottenSearchParamsSchema`, `resetPasswordSearchParamsSchema`, `emailVerificationSearchParamsSchema`, plus existing page schemas) with `safeParse` + redirects/notFound
> - Minor UI tweaks: width tokens updated (e.g., `md:w-lg`, `md:w-3xl`, `w-4xl`), grid/spacing calc adjustments, and small class refinements (e.g., `before:-inset-px`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86ea790279da252cbd545b11669f0b5439967d91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->