### PR TITLE
Implement Next.js App Router caching with cache tags and revalidation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,12 @@ import type { NextConfig } from "next";
 const withNextIntl = createNextIntlPlugin("./src/lib/i18n/index.ts");
 
 const nextConfig: NextConfig = withNextIntl({
+  cacheComponents: true,
+  cacheLife: {
+    minutes: { stale: 60, revalidate: 120, expire: 3600 },
+    hours: { stale: 300, revalidate: 3600, expire: 86400 },
+    places: { stale: 86400, revalidate: 2592000, expire: 2592000 },
+  },
   experimental: {
     serverActions: {
       bodySizeLimit: "2500KB",

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/_components/brewery-reviews/brewery-all-reviews/index.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/_components/brewery-reviews/brewery-all-reviews/index.tsx
@@ -7,8 +7,10 @@ import ReviewPictureGrid from "@/app/_components/review-picture-grid";
 import ReviewPictureGridLoader from "@/app/_components/review-picture-grid/loader";
 import { ChipTabContent } from "@/app/_components/ui/chip-tabs";
 import Pagination from "@/app/_components/ui/pagination";
-import { getAllBreweryReviews } from "@/domain/breweries";
-import { getLatestBreweryPublicPictures } from "@/domain/breweries";
+import {
+  getCachedAllBreweryReviews,
+  getCachedLatestBreweryPublicPictures,
+} from "@/domain/breweries/cache";
 
 interface BreweryAllReviewsProps {
   brewerySlug: string;
@@ -21,9 +23,9 @@ const BreweryAllReviews = async ({
 }: BreweryAllReviewsProps) => {
   const t = await getTranslations();
 
-  const latestPicturesPromise = getLatestBreweryPublicPictures({ brewerySlug });
+  const latestPicturesPromise = getCachedLatestBreweryPublicPictures({ brewerySlug });
 
-  const allReviewsPromise = getAllBreweryReviews({
+  const allReviewsPromise = getCachedAllBreweryReviews({
     brewerySlug,
     page,
   });

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/_components/beer-reviews/beer-all-reviews/index.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/_components/beer-reviews/beer-all-reviews/index.tsx
@@ -7,8 +7,10 @@ import ReviewPictureGrid from "@/app/_components/review-picture-grid";
 import ReviewPictureGridLoader from "@/app/_components/review-picture-grid/loader";
 import { ChipTabContent } from "@/app/_components/ui/chip-tabs";
 import Pagination from "@/app/_components/ui/pagination";
-import { getAllBeerReviews } from "@/domain/beers";
-import { getLatestPublicPictures } from "@/domain/beers";
+import {
+  getCachedAllBeerReviews,
+  getCachedLatestPublicPictures,
+} from "@/domain/beers/cache";
 
 interface BeerAllReviewsProps {
   beerId: string;
@@ -18,9 +20,9 @@ interface BeerAllReviewsProps {
 const BeerAllReviews = async ({ beerId, page }: BeerAllReviewsProps) => {
   const t = await getTranslations();
 
-  const latestPicturesPromise = getLatestPublicPictures({ beerId });
+  const latestPicturesPromise = getCachedLatestPublicPictures({ beerId });
 
-  const allReviewsPromise = getAllBeerReviews({
+  const allReviewsPromise = getCachedAllBeerReviews({
     beerId,
     page,
   });

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/json-ld.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/json-ld.tsx
@@ -1,5 +1,8 @@
 import JsonLd from "@/app/_components/json-ld";
-import { getAllBeerReviews, getBeerAggregateRatingById } from "@/domain/beers";
+import {
+  getCachedAllBeerReviews,
+  getCachedBeerAggregateRatingById,
+} from "@/domain/beers/cache";
 import type { Beer } from "@/domain/beers/types";
 import { Routes } from "@/lib/routes";
 import { generatePath } from "@/lib/routes/utils";
@@ -13,8 +16,8 @@ interface BeerJsonLdProps {
 
 const BeerJsonLd = async ({ beer }: BeerJsonLdProps) => {
   const [aggregateRating, latestReviews] = await Promise.all([
-    getBeerAggregateRatingById(beer.id),
-    getAllBeerReviews({ beerId: beer.id, limit: 5, page: 1 }),
+    getCachedBeerAggregateRatingById(beer.id),
+    getCachedAllBeerReviews({ beerId: beer.id, limit: 5, page: 1 }),
   ]);
 
   const beerUrl = getAbsoluteUrl(

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/page.tsx
@@ -7,7 +7,7 @@ import BeerJsonLd from "@/app/[locale]/(business)/(with-header)/breweries/[brewe
 import { beerPageSearchParamsSchema } from "@/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/beers/[beerSlug]/schemas";
 import ShareButton from "@/app/_components/share-button";
 import Button from "@/app/_components/ui/button";
-import { getBeerBySlug } from "@/domain/beers";
+import { getCachedBeerBySlug } from "@/domain/beers/cache";
 import { config } from "@/lib/config";
 import { publicConfig } from "@/lib/config/client-config";
 import { StaticGenerationMode } from "@/lib/config/types";
@@ -76,7 +76,7 @@ export async function generateMetadata({
 
   const t = await getTranslations({ locale });
 
-  const beer = await getBeerBySlug(beerSlug, brewerySlug).catch(() =>
+  const beer = await getCachedBeerBySlug(beerSlug, brewerySlug).catch(() =>
     notFound(),
   );
 
@@ -133,7 +133,7 @@ const BeerPage = async ({
     });
   }
 
-  const beer = await getBeerBySlug(beerSlug, brewerySlug).catch(() =>
+  const beer = await getCachedBeerBySlug(beerSlug, brewerySlug).catch(() =>
     notFound(),
   );
 

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/json-ld.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/json-ld.tsx
@@ -1,8 +1,8 @@
 import JsonLd from "@/app/_components/json-ld";
 import {
-  getAllBreweryReviews,
-  getBreweryAggregateRatingById,
-} from "@/domain/breweries";
+  getCachedAllBreweryReviews,
+  getCachedBreweryAggregateRatingById,
+} from "@/domain/breweries/cache";
 import type { Brewery } from "@/domain/breweries/types";
 import { Routes } from "@/lib/routes";
 import { generatePath } from "@/lib/routes/utils";
@@ -16,8 +16,8 @@ interface BreweryJsonLdProps {
 
 const BreweryJsonLd = async ({ brewery }: BreweryJsonLdProps) => {
   const [aggregateRating, latestReviews] = await Promise.all([
-    getBreweryAggregateRatingById(brewery.id),
-    getAllBreweryReviews({ brewerySlug: brewery.slug, limit: 5, page: 1 }),
+    getCachedBreweryAggregateRatingById(brewery.slug, brewery.id),
+    getCachedAllBreweryReviews({ brewerySlug: brewery.slug, limit: 5, page: 1 }),
   ]);
 
   const breweryUrl = getAbsoluteUrl(

--- a/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/page.tsx
@@ -8,7 +8,7 @@ import BreweryTabList from "@/app/[locale]/(business)/(with-header)/breweries/[b
 import BreweryJsonLd from "@/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/json-ld";
 import { brewerySearchParamsSchema } from "@/app/[locale]/(business)/(with-header)/breweries/[brewerySlug]/schemas";
 import { Tabs, TabContent } from "@/app/_components/ui/tabs";
-import { getBreweryBySlug } from "@/domain/breweries";
+import { getCachedBreweryBySlug } from "@/domain/breweries/cache";
 import { config } from "@/lib/config";
 import { publicConfig } from "@/lib/config/client-config";
 import { StaticGenerationMode } from "@/lib/config/types";
@@ -66,7 +66,7 @@ export async function generateMetadata({
 
   const { brewerySlug } = await params;
 
-  const brewery = await getBreweryBySlug(brewerySlug).catch(() => notFound());
+  const brewery = await getCachedBreweryBySlug(brewerySlug).catch(() => notFound());
 
   const title = `${brewery.name} | ${publicConfig.appName}`;
   const description = t("breweryPage.metadata.description", {
@@ -114,7 +114,7 @@ const BreweryPage = async ({
     });
   }
 
-  const brewery = await getBreweryBySlug(brewerySlug).catch(() => notFound());
+  const brewery = await getCachedBreweryBySlug(brewerySlug).catch(() => notFound());
 
   if (brewery.slug !== brewerySlug) {
     redirect({

--- a/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
+++ b/src/app/[locale]/(business)/(with-header)/users/[username]/page.tsx
@@ -10,11 +10,11 @@ import ReviewPictureGrid from "@/app/_components/review-picture-grid";
 import ReviewPictureGridLoader from "@/app/_components/review-picture-grid/loader";
 import Pagination from "@/app/_components/ui/pagination";
 import {
-  getReviewsByUser,
-  getUserByUsername,
-  getLatestPicturesByUser,
-  getUserVisitedCountries,
-} from "@/domain/users";
+  getCachedReviewsByUser,
+  getCachedUserByUsername,
+  getCachedLatestPicturesByUser,
+  getCachedUserVisitedCountries,
+} from "@/domain/users/cache";
 import { publicConfig } from "@/lib/config/client-config";
 import { redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
@@ -29,7 +29,7 @@ export async function generateMetadata({
 }: PageProps<"/[locale]/users/[username]">): Promise<Metadata> {
   const { username } = await params;
 
-  const user = await getUserByUsername(username).catch(() => notFound());
+  const user = await getCachedUserByUsername(username).catch(() => notFound());
 
   return {
     title: `${user.username} | ${publicConfig.appName}`,
@@ -56,7 +56,7 @@ const ProfilePage = async ({
     });
   }
 
-  const user = await getUserByUsername(username).catch(() => notFound());
+  const user = await getCachedUserByUsername(username).catch(() => notFound());
 
   if (user.username !== username) {
     redirect({
@@ -69,15 +69,21 @@ const ProfilePage = async ({
     });
   }
 
-  const latestPicturesPromise = getLatestPicturesByUser({ userId: user.id });
+  const latestPicturesPromise = getCachedLatestPicturesByUser(
+    { userId: user.id },
+    user.username,
+  );
 
   const [reviews, visitedCountries] = await Promise.all([
-    getReviewsByUser({
-      userId: user.id,
-      page: searchParamsResult.data.page,
-      limit: 10,
-    }),
-    getUserVisitedCountries(user.id),
+    getCachedReviewsByUser(
+      {
+        userId: user.id,
+        page: searchParamsResult.data.page,
+        limit: 10,
+      },
+      user.username,
+    ),
+    getCachedUserVisitedCountries(user.id, user.username),
   ]);
 
   return (

--- a/src/app/[locale]/(business)/(without-header)/breweries/[brewerySlug]/beers/[beerSlug]/review/actions.ts
+++ b/src/app/[locale]/(business)/(without-header)/breweries/[brewerySlug]/beers/[beerSlug]/review/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { parseWithZod } from "@conform-to/zod/v4";
+import { updateTag } from "next/cache";
 import { getLocale } from "next-intl/server";
 
 import { reviewSchema } from "@/app/[locale]/(business)/(without-header)/breweries/[brewerySlug]/beers/[beerSlug]/review/schemas";
@@ -14,6 +15,7 @@ import {
 } from "@/domain/beers/errors";
 import { getCurrentUser } from "@/lib/auth";
 import { redirect } from "@/lib/i18n";
+import prisma from "@/lib/prisma";
 import { Routes } from "@/lib/routes";
 import { generatePath } from "@/lib/routes/utils";
 
@@ -102,6 +104,22 @@ export const reviewAction = async (
       resetForm: false,
       formErrors: ["createReviewPage.errors.SOMETHING_WENT_WRONG"],
     });
+  }
+
+  // Invalidate caches affected by the new review
+  updateTag(`beer:${createdReview.beer.slug}`);
+  updateTag(`beer:${createdReview.beerId}:reviews`);
+  updateTag(`brewery:${createdReview.beer.brewery.slug}`);
+  updateTag(`brewery:${createdReview.beer.brewery.slug}:reviews`);
+
+  // Invalidate the reviewer's profile cache
+  const reviewer = await prisma.users.findUnique({
+    where: { id: createdReview.userId },
+    select: { username: true },
+  });
+  if (reviewer) {
+    updateTag(`user:${reviewer.username.toLowerCase()}`);
+    updateTag(`user:${reviewer.username.toLowerCase()}:reviews`);
   }
 
   redirect({

--- a/src/app/[locale]/(business)/(without-header)/create/beer/actions.ts
+++ b/src/app/[locale]/(business)/(without-header)/create/beer/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { parseWithZod } from "@conform-to/zod/v4";
+import { updateTag } from "next/cache";
 import { getLocale } from "next-intl/server";
 
 import { createBeer } from "@/domain/beers";
@@ -40,6 +41,9 @@ export const createBeerAction = async (
   }
 
   const beer = await createBeer(submission.value);
+
+  // Invalidate brewery cache since it shows beer list
+  updateTag(`brewery:${beer.brewery.slug}`);
 
   redirect({
     href: generatePath(Routes.BEER, {

--- a/src/app/[locale]/(business)/(without-header)/create/beer/page.tsx
+++ b/src/app/[locale]/(business)/(without-header)/create/beer/page.tsx
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import CreateBeerForm from "@/app/[locale]/(business)/(without-header)/create/beer/_components/form";
-import { getColors, getStyleCategories } from "@/domain/beers";
+import { getCachedColors, getCachedStyleCategories } from "@/domain/beers/cache";
 import { auth } from "@/lib/auth/server";
 import { redirect } from "@/lib/i18n";
 import { Routes } from "@/lib/routes";
@@ -29,8 +29,8 @@ const CreateBeerPage = async ({
   }
 
   const [styleCategories, colors] = await Promise.all([
-    getStyleCategories(),
-    getColors(),
+    getCachedStyleCategories(),
+    getCachedColors(),
   ]);
 
   return (

--- a/src/app/[locale]/(business)/(without-header)/users/[username]/reviews/[reviewSlug]/page.tsx
+++ b/src/app/[locale]/(business)/(without-header)/users/[username]/reviews/[reviewSlug]/page.tsx
@@ -25,7 +25,7 @@ import ReviewJsonLd from "@/app/[locale]/(business)/(without-header)/users/[user
 import ShareButton from "@/app/_components/share-button";
 import DescriptionList from "@/app/_components/ui/description-list";
 import { Separator } from "@/app/_components/ui/separator";
-import { getReviewByUsernameAndSlug } from "@/domain/users";
+import { getCachedReviewByUsernameAndSlug } from "@/domain/users/cache";
 import type { Review } from "@/domain/users/types";
 import { publicConfig } from "@/lib/config/client-config";
 import { Link } from "@/lib/i18n";
@@ -42,7 +42,7 @@ export async function generateMetadata({
   const { locale, username, reviewSlug } = await params;
   const t = await getTranslations({ locale });
 
-  const review = await getReviewByUsernameAndSlug(username, reviewSlug).catch(
+  const review = await getCachedReviewByUsernameAndSlug(username, reviewSlug).catch(
     () => notFound(),
   );
 
@@ -96,7 +96,7 @@ const UserReviewPage = async ({
   const t = await getTranslations({ locale });
   const formatter = await getFormatter({ locale });
 
-  const review = await getReviewByUsernameAndSlug(username, reviewSlug).catch(
+  const review = await getCachedReviewByUsernameAndSlug(username, reviewSlug).catch(
     () => notFound(),
   );
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,50 @@
+import { revalidateTag } from "next/cache";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const expectedKey = process.env["REVALIDATION_API_KEY"];
+
+  if (!expectedKey || authHeader !== `Bearer ${expectedKey}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !("tags" in body) ||
+    !Array.isArray(body.tags) ||
+    body.tags.length === 0
+  ) {
+    return NextResponse.json(
+      { error: "Missing or invalid 'tags' array in request body" },
+      { status: 400 },
+    );
+  }
+
+  const invalidatedTags: string[] = [];
+
+  for (const tag of body.tags) {
+    if (typeof tag !== "string" || tag.length === 0 || tag.length > 256) {
+      continue;
+    }
+
+    revalidateTag(tag, "max");
+    invalidatedTags.push(tag);
+  }
+
+  return NextResponse.json({
+    success: true,
+    invalidatedTags,
+  });
+}

--- a/src/domain/beers/cache.ts
+++ b/src/domain/beers/cache.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+
+import {
+  getBeerBySlug as _getBeerBySlug,
+  getBeerAggregateRatingById as _getBeerAggregateRatingById,
+  getColors as _getColors,
+  getStyleCategories as _getStyleCategories,
+  getAllBeerReviews as _getAllBeerReviews,
+  getLatestPublicPictures as _getLatestPublicPictures,
+} from "@/domain/beers";
+import type { PaginationParams } from "@/lib/pagination/types";
+
+export async function getCachedBeerBySlug(
+  beerSlug: string,
+  brewerySlug: string,
+) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(`beer:${beerSlug}`);
+  return _getBeerBySlug(beerSlug, brewerySlug);
+}
+
+export async function getCachedBeerAggregateRatingById(beerId: string) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(`beer:${beerId}:reviews`);
+  return _getBeerAggregateRatingById(beerId);
+}
+
+export async function getCachedColors() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("reference:colors");
+  return _getColors();
+}
+
+export async function getCachedStyleCategories() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("reference:styles");
+  return _getStyleCategories();
+}
+
+export async function getCachedAllBeerReviews(
+  params: PaginationParams<{ beerId: string }>,
+) {
+  "use cache";
+  cacheLife("minutes");
+  cacheTag(`beer:${params.beerId}:reviews`);
+  return _getAllBeerReviews(params);
+}
+
+export async function getCachedLatestPublicPictures(params: {
+  beerId: string;
+  count?: number;
+}) {
+  "use cache";
+  cacheLife("minutes");
+  cacheTag(`beer:${params.beerId}:reviews`);
+  return _getLatestPublicPictures(params);
+}

--- a/src/domain/breweries/cache.ts
+++ b/src/domain/breweries/cache.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+
+import {
+  getBreweryBySlug as _getBreweryBySlug,
+  getBreweryAggregateRatingById as _getBreweryAggregateRatingById,
+  getAllBreweryReviews as _getAllBreweryReviews,
+  getLatestBreweryPublicPictures as _getLatestBreweryPublicPictures,
+} from "@/domain/breweries";
+import type { PaginationParams } from "@/lib/pagination/types";
+
+export async function getCachedBreweryBySlug(brewerySlug: string) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(`brewery:${brewerySlug}`);
+  return _getBreweryBySlug(brewerySlug);
+}
+
+export async function getCachedBreweryAggregateRatingById(
+  brewerySlug: string,
+  breweryId: string,
+) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(`brewery:${brewerySlug}:reviews`);
+  return _getBreweryAggregateRatingById(breweryId);
+}
+
+export async function getCachedAllBreweryReviews(
+  params: PaginationParams<{ brewerySlug: string }>,
+) {
+  "use cache";
+  cacheLife("minutes");
+  cacheTag(`brewery:${params.brewerySlug}:reviews`);
+  return _getAllBreweryReviews(params);
+}
+
+export async function getCachedLatestBreweryPublicPictures(params: {
+  brewerySlug: string;
+  count?: number;
+}) {
+  "use cache";
+  cacheLife("minutes");
+  cacheTag(`brewery:${params.brewerySlug}:reviews`);
+  return _getLatestBreweryPublicPictures(params);
+}

--- a/src/domain/users/cache.ts
+++ b/src/domain/users/cache.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+
+import {
+  getUserByUsername as _getUserByUsername,
+  getReviewsByUser as _getReviewsByUser,
+  getLatestPicturesByUser as _getLatestPicturesByUser,
+  getReviewByUsernameAndSlug as _getReviewByUsernameAndSlug,
+  getUserVisitedCountries as _getUserVisitedCountries,
+} from "@/domain/users";
+import type { PaginationParams } from "@/lib/pagination/types";
+
+export async function getCachedUserByUsername(username: string) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(`user:${username.toLowerCase()}`);
+  return _getUserByUsername(username);
+}
+
+export async function getCachedReviewsByUser(
+  params: PaginationParams<{ userId: string }>,
+  username: string,
+) {
+  "use cache";
+  cacheLife("minutes");
+  cacheTag(`user:${username.toLowerCase()}:reviews`);
+  return _getReviewsByUser(params);
+}
+
+export async function getCachedLatestPicturesByUser(
+  params: { userId: string; count?: number },
+  username: string,
+) {
+  "use cache";
+  cacheLife("minutes");
+  cacheTag(`user:${username.toLowerCase()}:reviews`);
+  return _getLatestPicturesByUser(params);
+}
+
+export async function getCachedReviewByUsernameAndSlug(
+  username: string,
+  reviewSlug: string,
+) {
+  "use cache";
+  cacheLife("days");
+  cacheTag(`review:${username.toLowerCase()}:${reviewSlug}`);
+  return _getReviewByUsernameAndSlug(username, reviewSlug);
+}
+
+export async function getCachedUserVisitedCountries(
+  userId: string,
+  username: string,
+) {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(`user:${username.toLowerCase()}`);
+  return _getUserVisitedCountries(userId);
+}

--- a/src/lib/places/index.ts
+++ b/src/lib/places/index.ts
@@ -1,16 +1,22 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 
 import { UnknownPlaceError } from "@/lib/places/errors";
 import { placesClient } from "@/lib/places/gcp";
 import { transformAutocompletePlacesSuggestionToAutocompleteLocation } from "@/lib/places/transforms";
 import type { AutocompleteLocation, Place } from "@/lib/places/types";
 
-const getAutocompleteSuggestionsUncached = async (
+export const GOOGLE_PLACES_CACHE_TAG = "google-places";
+
+export async function getAutocompleteSuggestions(
   input: string,
   sessionToken: string,
-): Promise<AutocompleteLocation[]> => {
+): Promise<AutocompleteLocation[]> {
+  "use cache";
+  cacheLife("places");
+  cacheTag(GOOGLE_PLACES_CACHE_TAG);
+
   const [response] = await placesClient.autocompletePlaces({
     input,
     sessionToken,
@@ -23,12 +29,16 @@ const getAutocompleteSuggestionsUncached = async (
   return response.suggestions
     .map(transformAutocompletePlacesSuggestionToAutocompleteLocation)
     .filter((location) => location !== undefined);
-};
+}
 
-const getPlaceDetailsUncached = async (
+export async function getPlaceDetails(
   placeId: string,
   sessionToken: string,
-): Promise<Place> => {
+): Promise<Place> {
+  "use cache";
+  cacheLife("places");
+  cacheTag(GOOGLE_PLACES_CACHE_TAG);
+
   const [response] = await placesClient.getPlace(
     {
       name: `places/${placeId}`,
@@ -56,18 +66,4 @@ const getPlaceDetailsUncached = async (
     name: response.displayName.text,
     address: response.shortFormattedAddress,
   };
-};
-
-export const GOOGLE_PLACES_CACHE_TAG = "google-places";
-const CACHE_REVALIDATE = 2_592_000; // 30 DAYS CACHE LIFE
-
-export const getAutocompleteSuggestions = unstable_cache(
-  getAutocompleteSuggestionsUncached,
-  [],
-  { revalidate: CACHE_REVALIDATE, tags: [GOOGLE_PLACES_CACHE_TAG] },
-);
-
-export const getPlaceDetails = unstable_cache(getPlaceDetailsUncached, [], {
-  revalidate: CACHE_REVALIDATE,
-  tags: [GOOGLE_PLACES_CACHE_TAG],
-});
+}


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive caching strategy for the Next.js App Router using the new `cacheLife` and `cacheTag` APIs, replacing the deprecated `unstable_cache` pattern. It includes cache wrapper functions for domain entities (beers, breweries, users) and a revalidation API endpoint for on-demand cache invalidation.

## Key Changes

- **New cache wrapper modules**: Created `cache.ts` files in domain layers (`beers`, `breweries`, `users`) that wrap data fetching functions with appropriate cache directives and tags
  - Beers: 6 cached functions with varying lifetimes (minutes to max)
  - Breweries: 4 cached functions with minutes to hours lifetimes
  - Users: 5 cached functions with minutes to days lifetimes
  - Google Places: Migrated from `unstable_cache` to new caching API with 30-day cache

- **Revalidation API endpoint** (`/api/revalidate`): New POST endpoint that accepts a Bearer token and invalidates cache tags on-demand, enabling external systems to trigger cache updates

- **Cache tag strategy**: Implemented hierarchical cache tags for granular invalidation:
  - Entity-level: `beer:{id}`, `brewery:{slug}`, `user:{username}`
  - Feature-level: `beer:{id}:reviews`, `brewery:{slug}:reviews`, `user:{username}:reviews`
  - Reference data: `reference:colors`, `reference:styles`

- **Server action cache invalidation**: Updated review creation and beer creation actions to call `updateTag()` for affected cache tags, ensuring related pages are invalidated when content changes

- **Next.js config updates**: Added `cacheComponents: true` and defined custom `cacheLife` durations:
  - `minutes`: 60s stale, 120s revalidate, 3600s expire
  - `hours`: 300s stale, 3600s revalidate, 86400s expire
  - `places`: 86400s stale, 2592000s revalidate, 2592000s expire

- **Component updates**: Replaced all direct domain function calls with cached variants throughout the application (user profiles, beer/brewery pages, review pages, JSON-LD generation)

## Implementation Details

- All cache wrappers use `"use cache"` directive with appropriate `cacheLife()` and `cacheTag()` calls
- Cache lifetimes are tuned per data type: reference data uses `max`, user-generated content uses `minutes`, entity metadata uses `hours`
- Revalidation API validates Bearer token and tag format (1-256 characters) before processing
- Server actions use `updateTag()` to invalidate related caches when reviews or beers are created
- Maintains backward compatibility by keeping original domain functions unchanged

https://claude.ai/code/session_01WBFE2EsCANm7tn8qKujjie